### PR TITLE
[Feature] Add async markdown rendering with syntax highlighting support

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/lsp/LspTestActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/lsp/LspTestActivity.kt
@@ -48,6 +48,8 @@ import io.github.rosemoe.sora.lsp.client.languageserver.serverdefinition.CustomL
 import io.github.rosemoe.sora.lsp.client.languageserver.wrapper.EventHandler
 import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.editor.LspProject
+import io.github.rosemoe.sora.lsp.editor.text.MarkdownCodeHighlighterRegistry
+import io.github.rosemoe.sora.lsp.editor.text.withEditorHighlighter
 import io.github.rosemoe.sora.lsp.events.EventType
 import io.github.rosemoe.sora.lsp.events.code.codeAction
 import io.github.rosemoe.sora.lsp.utils.asLspRange
@@ -148,7 +150,8 @@ class LspTestActivity : BaseEditorActivity() {
         )
 
         val luaServerDefinition =
-            object : CustomLanguageServerDefinition("lua",
+            object : CustomLanguageServerDefinition(
+                "lua",
                 ServerConnectProvider {
                     LocalSocketStreamConnectionProvider("lua-lsp")
                 }
@@ -169,6 +172,8 @@ class LspTestActivity : BaseEditorActivity() {
         lspProject = LspProject(projectPath)
 
         lspProject.addServerDefinition(luaServerDefinition)
+
+
 
         withContext(Dispatchers.Main) {
             lspEditor = lspProject.createEditor("$projectPath/sample.lua")
@@ -236,6 +241,16 @@ class LspTestActivity : BaseEditorActivity() {
                 }
             }
         )
+
+        MarkdownCodeHighlighterRegistry.global.withEditorHighlighter { languageName ->
+            if (languageName == "lua") {
+                Pair(
+                    TextMateLanguage.create("source.lua", false),
+                    TextMateColorScheme.create(ThemeRegistry.getInstance()).apply {
+                    }
+                )
+            } else null
+        }
 
         return TextMateLanguage.create(
             "source.lua", false

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
@@ -219,12 +219,10 @@ class LspEditor(
     val isShowHover
         get() = hoverWindowWeakReference.get()?.isShowing ?: false
 
-
     val isShowCodeActions
         get() = codeActionWindowWeakReference.get()?.isShowing ?: false
 
     var isEnableHover = true
-        get() = hoverWindow?.isEnabled() ?: false
         set(value) {
             field = value
             if (value) {
@@ -236,7 +234,6 @@ class LspEditor(
         }
 
     var isEnableSignatureHelp = true
-        get() = signatureHelpWindow?.isEnabled() ?: false
         set(value) {
             field = value
             if (value) {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
@@ -74,11 +74,9 @@ import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.jsonrpc.messages.Either
-import java.lang.RuntimeException
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.reflect.KClass
 
 class LspEditor(
     val project: LspProject,
@@ -134,10 +132,11 @@ class LspEditor(
             currentEditor.setEditorLanguage(currentLanguage)
 
             if (isEnableSignatureHelp) {
-                signatureHelpWindowWeakReference = WeakReference(SignatureHelpWindow(currentEditor))
+                signatureHelpWindowWeakReference =
+                    WeakReference(SignatureHelpWindow(currentEditor, coroutineScope))
             }
             if (isEnableHover) {
-                hoverWindowWeakReference = WeakReference(HoverWindow(currentEditor))
+                hoverWindowWeakReference = WeakReference(HoverWindow(currentEditor, coroutineScope))
             }
             if (isEnableInlayHint) {
                 currentEditor.registerInlayHintRenderer(TextInlayHintRenderer)
@@ -226,7 +225,9 @@ class LspEditor(
         set(value) {
             field = value
             if (value) {
-                editor?.let { hoverWindowWeakReference = WeakReference(HoverWindow(it)) }
+                editor?.let {
+                    hoverWindowWeakReference = WeakReference(HoverWindow(it, coroutineScope))
+                }
             } else {
                 hoverWindow?.setEnabled(false)
                 hoverWindowWeakReference.clear()
@@ -238,7 +239,12 @@ class LspEditor(
             field = value
             if (value) {
                 editor?.let {
-                    signatureHelpWindowWeakReference = WeakReference(SignatureHelpWindow(it))
+                    signatureHelpWindowWeakReference = WeakReference(
+                        SignatureHelpWindow(
+                            it,
+                            coroutineScope
+                        )
+                    )
                 }
             } else {
                 signatureHelpWindow?.setEnabled(false)

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/hover/HoverWindow.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/hover/HoverWindow.kt
@@ -16,12 +16,14 @@ import io.github.rosemoe.sora.widget.component.EditorAutoCompletion
 import io.github.rosemoe.sora.widget.component.EditorDiagnosticTooltipWindow
 import io.github.rosemoe.sora.widget.component.EditorTextActionWindow
 import io.github.rosemoe.sora.widget.getComponent
+import kotlinx.coroutines.CoroutineScope
 import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 
 open class HoverWindow(
     editor: CodeEditor,
+    internal val coroutineScope: CoroutineScope
 ) : EditorPopupWindow(
     editor,
     FEATURE_HIDE_WHEN_FAST_SCROLL or FEATURE_SCROLL_AS_CONTENT

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/signature/SignatureHelpWindow.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/signature/SignatureHelpWindow.kt
@@ -37,10 +37,12 @@ import io.github.rosemoe.sora.widget.CodeEditor
 import io.github.rosemoe.sora.widget.base.EditorPopupWindow
 import io.github.rosemoe.sora.widget.component.EditorDiagnosticTooltipWindow
 import io.github.rosemoe.sora.widget.getComponent
+import kotlinx.coroutines.CoroutineScope
 import org.eclipse.lsp4j.SignatureHelp
 
 open class SignatureHelpWindow(
     editor: CodeEditor,
+    val coroutineScope: CoroutineScope,
 ) : EditorPopupWindow(
     editor,
     FEATURE_HIDE_WHEN_FAST_SCROLL or FEATURE_SCROLL_AS_CONTENT

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/EditorLanguageHighlighter.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/EditorLanguageHighlighter.kt
@@ -1,0 +1,172 @@
+package io.github.rosemoe.sora.lsp.editor.text
+
+import android.graphics.Typeface
+import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.text.style.StrikethroughSpan
+import android.text.style.StyleSpan
+import android.util.Log
+import io.github.rosemoe.sora.lang.Language
+import io.github.rosemoe.sora.lang.analysis.AnalyzeManager
+import io.github.rosemoe.sora.lang.analysis.StyleReceiver
+import io.github.rosemoe.sora.lang.brackets.BracketsProvider
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer
+import io.github.rosemoe.sora.lang.styling.Span
+import io.github.rosemoe.sora.lang.styling.Styles
+import io.github.rosemoe.sora.lang.styling.TextStyle
+import io.github.rosemoe.sora.text.Content
+import io.github.rosemoe.sora.text.ContentReference
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
+import kotlin.coroutines.suspendCoroutine
+
+class EditorMarkdownCodeHighlighterProvider(
+    val editorContextProvider: (languageName: LanguageName) -> Pair<Language, EditorColorScheme>?
+) : MarkdownCodeHighlighterRegistry.CodeHighlighterProvider {
+    override fun provide(language: LanguageName): MarkdownCodeHighlighter? {
+        val context = editorContextProvider(language) ?: return null
+        return EditorMarkdownCodeHighlighter(context.first, context.second)
+    }
+}
+
+fun MarkdownCodeHighlighterRegistry.withEditorHighlighter(editorContextProvider: (languageName: LanguageName) -> Pair<Language, EditorColorScheme>?)  {
+    withProvider(EditorMarkdownCodeHighlighterProvider(editorContextProvider))
+}
+
+class EditorMarkdownCodeHighlighter(val editorLanguage: Language, val editorSchema: EditorColorScheme) :
+    AsyncMarkdownCodeHighlighter() {
+
+    override suspend fun highlightAsync(
+        code: String,
+        language: String?,
+        codeTypeface: Typeface
+    ) = suspendCoroutine { continuation ->
+
+        val content = Content(code)
+        val analyzeManager = editorLanguage.analyzeManager
+
+        analyzeManager.setReceiver(object : EmptyStyleReceiver() {
+            override fun setStyles(sourceManager: AnalyzeManager, styles: Styles?) {
+                if (styles == null) {
+                    return
+                }
+                runCatching {
+                    continuation.resumeWith(
+                        Result.success(
+                            styles.toSpanned(
+                                content,
+                                editorSchema,
+                                codeTypeface
+                            )
+                        )
+                    )
+                }.onFailure {
+                    continuation.resumeWith(Result.failure(it))
+                }
+            }
+        })
+
+        analyzeManager.reset(ContentReference(content), Bundle())
+    }
+
+    private fun Styles.toSpanned(
+        content: Content,
+        colorScheme: EditorColorScheme,
+        typeface: Typeface
+    ): Spanned {
+        val builder = SpannableStringBuilder(content.toString())
+        val spans = this.spans ?: return builder
+        val reader = spans.read()
+        val lineCount = content.lineCount
+        for (lineIndex in 0 until lineCount) {
+            reader.moveToLine(lineIndex)
+            val spanCount = reader.getSpanCount()
+            val lineStart = content.getCharIndex(lineIndex, 0)
+            val lineEnd = content.getCharIndex(lineIndex, content.getColumnCount(lineIndex))
+            for (i in 0 until spanCount) {
+                val span = reader.getSpanAt(i)
+                val start = lineStart + span.column
+                val end = if (i < spanCount - 1) {
+                    lineStart + reader.getSpanAt(i + 1).column
+                } else {
+                    lineEnd
+                }
+                if (start >= end || start >= builder.length) continue
+                applySpan(
+                    builder,
+                    span,
+                    start,
+                    end.coerceAtMost(builder.length),
+                    colorScheme,
+                    typeface
+                )
+            }
+        }
+        return builder
+    }
+
+    private fun applySpan(
+        builder: SpannableStringBuilder,
+        span: Span,
+        start: Int,
+        end: Int,
+        colorScheme: EditorColorScheme,
+        typeface: Typeface
+    ) {
+        val style = span.style
+        val foregroundColorId = TextStyle.getForegroundColorId(style)
+
+        val foregroundColor = colorScheme.getColor(foregroundColorId)
+        println("$span ${foregroundColor.toString(16)} $colorScheme")
+        builder.setSpan(
+            ForegroundColorSpan(foregroundColor),
+            start,
+            end,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+
+        if (TextStyle.isBold(style)) {
+            builder.setSpan(StyleSpan(Typeface.BOLD), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+        if (TextStyle.isItalics(style)) {
+            builder.setSpan(
+                StyleSpan(Typeface.ITALIC),
+                start,
+                end,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+        if (TextStyle.isStrikeThrough(style)) {
+            builder.setSpan(StrikethroughSpan(), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+}
+
+open class EmptyStyleReceiver : StyleReceiver {
+    override fun setStyles(
+        sourceManager: AnalyzeManager,
+        styles: Styles?
+    ) {
+        setStyles(sourceManager, styles, null)
+    }
+
+    override fun setStyles(
+        sourceManager: AnalyzeManager,
+        styles: Styles?,
+        action: Runnable?
+    ) {
+    }
+
+    override fun setDiagnostics(
+        sourceManager: AnalyzeManager,
+        diagnostics: DiagnosticsContainer?
+    ) {
+    }
+
+    override fun updateBracketProvider(
+        sourceManager: AnalyzeManager,
+        provider: BracketsProvider?
+    ) {
+    }
+}

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/EditorLanguageHighlighter.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/EditorLanguageHighlighter.kt
@@ -118,7 +118,7 @@ class EditorMarkdownCodeHighlighter(val editorLanguage: Language, val editorSche
         val foregroundColorId = TextStyle.getForegroundColorId(style)
 
         val foregroundColor = colorScheme.getColor(foregroundColorId)
-        println("$span ${foregroundColor.toString(16)} $colorScheme")
+
         builder.setSpan(
             ForegroundColorSpan(foregroundColor),
             start,

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/MarkdownCodeHighlighter.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/MarkdownCodeHighlighter.kt
@@ -1,0 +1,22 @@
+package io.github.rosemoe.sora.lsp.editor.text
+
+import android.graphics.Typeface
+import android.text.Spanned
+
+interface MarkdownCodeHighlighter {
+    val isAsync: Boolean get() = false
+
+    fun highlight(code: String, language: String?, codeTypeface: Typeface): Spanned
+
+    suspend fun highlightAsync(code: String, language: String?, codeTypeface: Typeface): Spanned = highlight(code, language, codeTypeface)
+}
+
+abstract class AsyncMarkdownCodeHighlighter : MarkdownCodeHighlighter {
+    override val isAsync: Boolean get() = true
+
+    override fun highlight(code: String, language: String?, codeTypeface: Typeface): Spanned {
+        throw UnsupportedOperationException("Use highlightAsync for async highlighter")
+    }
+
+    abstract override suspend fun highlightAsync(code: String, language: String?, codeTypeface: Typeface): Spanned
+}

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/MarkdownCodeHighlighterRegistry.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/text/MarkdownCodeHighlighterRegistry.kt
@@ -1,0 +1,105 @@
+package io.github.rosemoe.sora.lsp.editor.text
+
+import android.graphics.Typeface
+import android.util.Log
+
+class MarkdownCodeHighlighterRegistry {
+    private val highlighters = mutableMapOf<String, MarkdownCodeHighlighter>()
+    private val aliases = mutableMapOf<String, String>()
+    private val providers = mutableListOf<CodeHighlighterProvider>()
+
+    fun withProvider(provider: CodeHighlighterProvider): Disposable {
+        providers.add(provider)
+        return Disposable { providers.remove(provider) }
+    }
+
+    fun register(language: LanguageName, highlighter: MarkdownCodeHighlighter): Disposable {
+        val key = language.lowercase()
+        highlighters[key] = highlighter
+        return Disposable { highlighters.remove(key) }
+    }
+
+    fun registerWithAlias(alias: LanguageAlias, highlighter: MarkdownCodeHighlighter): Disposable {
+        val target = alias.target.lowercase()
+        highlighters[target] = highlighter
+        alias.aliases.forEach { a ->
+            aliases[a.lowercase()] = target
+        }
+        return Disposable {
+            highlighters.remove(target)
+            alias.aliases.forEach { a ->
+                aliases.remove(a.lowercase())
+            }
+        }
+    }
+
+    fun unregister(language: String) {
+        val key = language.lowercase()
+        highlighters.remove(key)
+        aliases.entries.removeIf { it.value == key }
+    }
+
+    fun addAlias(from: LanguageName, to: LanguageName) {
+        aliases[from.lowercase()] = to.lowercase()
+    }
+
+    fun highlight(code: String, language: LanguageName?, codeTypeface: Typeface): HighlightResult {
+        println("$code $language")
+        if (language == null) return HighlightResult(code, false)
+        val resolved = aliases[language.lowercase()] ?: language.lowercase()
+        val highlighter = highlighters[resolved] ?: providers.firstNotNullOfOrNull { it.provide(resolved) }
+            ?.also { highlighters[resolved] = it }
+        if (highlighter == null) return HighlightResult(code, false)
+        if (highlighter.isAsync) {
+            Log.w("CodeHighlighterRegistry", "Async highlighter for '$resolved' called in sync context")
+            return HighlightResult(code, true)
+        }
+        return HighlightResult(highlighter.highlight(code, language, codeTypeface), false)
+    }
+
+    suspend fun highlightAsync(code: String, language: LanguageName?, codeTypeface: Typeface): CharSequence {
+        if (language == null) return code
+        val resolved = aliases[language.lowercase()] ?: language.lowercase()
+        val highlighter = highlighters[resolved] ?: providers.firstNotNullOfOrNull { it.provide(resolved) }
+            ?.also { highlighters[resolved] = it }
+        return highlighter?.highlightAsync(code, language, codeTypeface) ?: code
+    }
+
+    data class HighlightResult(
+        val content: CharSequence,
+        val needsAsync: Boolean
+    )
+
+    data class LanguageAlias(
+        val target: LanguageName,
+        val aliases: List<LanguageName> = emptyList()
+    ) {
+        companion object {
+            val Kotlin = LanguageAlias("kotlin", listOf("kt"))
+            val Java = LanguageAlias("java")
+            val JavaScript = LanguageAlias("javascript", listOf("js", "jsx"))
+            val TypeScript = LanguageAlias("typescript", listOf("ts", "tsx"))
+            val Python = LanguageAlias("python", listOf("py"))
+            val Cpp = LanguageAlias("cpp", listOf("c++"))
+            val CSharp = LanguageAlias("csharp", listOf("c#", "cs"))
+            val Ruby = LanguageAlias("ruby", listOf("rb"))
+            val Shell = LanguageAlias("shell", listOf("sh", "bash", "zsh"))
+            val Yaml = LanguageAlias("yaml", listOf("yml"))
+            val Markdown = LanguageAlias("markdown", listOf("md"))
+        }
+    }
+
+    companion object {
+        val global = MarkdownCodeHighlighterRegistry()
+    }
+
+    fun interface Disposable {
+        fun dispose()
+    }
+
+    fun interface CodeHighlighterProvider {
+        fun provide(language: LanguageName): MarkdownCodeHighlighter?
+    }
+}
+
+typealias LanguageName = String

--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
@@ -24,18 +24,15 @@
 package io.github.rosemoe.sora.langs.textmate;
 
 import android.graphics.Color;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import org.eclipse.tm4e.core.internal.theme.Theme;
 import org.eclipse.tm4e.core.internal.theme.raw.IRawTheme;
 import org.eclipse.tm4e.core.internal.theme.raw.RawTheme;
 import org.eclipse.tm4e.core.registry.IThemeSource;
+
+import java.util.List;
 
 import io.github.rosemoe.sora.langs.textmate.registry.ThemeRegistry;
 import io.github.rosemoe.sora.langs.textmate.registry.model.ThemeModel;
@@ -56,29 +53,28 @@ public class TextMateColorScheme extends EditorColorScheme implements ThemeRegis
 
     private final ThemeRegistry themeRegistry;
 
-    public TextMateColorScheme(ThemeRegistry themeRegistry, ThemeModel themeModel) throws Exception {
+    public TextMateColorScheme(ThemeRegistry themeRegistry, ThemeModel themeModel) {
         this.themeRegistry = themeRegistry;
-
         currentTheme = themeModel;
+        setTheme(themeModel);
     }
 
     @Deprecated
-    public static TextMateColorScheme create(IThemeSource themeSource) throws Exception {
+    public static TextMateColorScheme create(IThemeSource themeSource) {
         return create(new ThemeModel(themeSource));
     }
 
-    public static TextMateColorScheme create(ThemeModel themeModel) throws Exception {
+    public static TextMateColorScheme create(ThemeModel themeModel) {
         return create(ThemeRegistry.getInstance(), themeModel);
     }
 
-    public static TextMateColorScheme create(ThemeRegistry themeRegistry) throws Exception {
+    public static TextMateColorScheme create(ThemeRegistry themeRegistry) {
         return create(ThemeRegistry.getInstance(), themeRegistry.getCurrentThemeModel());
     }
 
-    public static TextMateColorScheme create(ThemeRegistry themeRegistry, ThemeModel themeModel) throws Exception {
+    public static TextMateColorScheme create(ThemeRegistry themeRegistry, ThemeModel themeModel) {
         return new TextMateColorScheme(themeRegistry, themeModel);
     }
-
 
     public void setTheme(ThemeModel themeModel) {
         currentTheme = themeModel;
@@ -311,8 +307,10 @@ public class TextMateColorScheme extends EditorColorScheme implements ThemeRegis
                     try {
                         color = theme.getColor(type - 255);
                     } catch (IndexOutOfBoundsException e) {
+                        e.printStackTrace();
                         return super.getColor(TEXT_NORMAL);
                     }
+                    System.out.println("color " + color);
                     var newColor = (color != null && !"@default".equalsIgnoreCase(color)) ?
                             ColorUtils.parseRGBAToARGB(color) : super.getColor(TEXT_NORMAL);
                     super.colors.put(type, newColor);


### PR DESCRIPTION
This PR adds async markdown rendering with syntax highlighting support for LSP editor hover and signature help windows.

## New Features

- Add async markdown rendering system with MarkdownCodeHighlighter interface
- Add MarkdownCodeHighlighterRegistry for managing code highlighter providers
- Add EditorLanguageHighlighter for syntax highlighting in markdown code blocks
- Support coroutine-based async rendering in hover and signature help windows

## Bug Fixes

- Remove redundant getter overrides in LspEditor

## Other Changes

- Refactor SimpleMarkdownRenderer to object with static render/renderAsync methods
- Update HoverWindow and SignatureHelpWindow to accept CoroutineScope parameter
- Remove Exception declarations in TextMateColorScheme methods
- Add example usage in LspTestActivity